### PR TITLE
Remove reference to missing file 

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 <script src="assets/js/libs/jquery-2.1.4.min.js"></script>
 <script src="assets/js/libs/underscore.min.js"></script>
 <script src="assets/js/gaem/gaem.js"></script>
-<script src="assets/js/gaem/gaem.fetchdata.js"></script>
 <script src="assets/js/gaem/gaem.load.js"></script>
 <script src="assets/js/gaem/gaem.utilities.js"></script>
 <script type="text/template" class="template-spinner">


### PR DESCRIPTION
The deploy on netlify (https://shotteboksen.netlify.app/) stopped working recently and it seems like the culprit being the line in index.html referencing an old script. 

And yes, I also think it's hilarious that I'm making a PR on this old thing. 